### PR TITLE
fix #94 如果存在返回包，sqlmap的RequestAsFile是返回包的内容

### DIFF
--- a/src/config/ConfigEntry.java
+++ b/src/config/ConfigEntry.java
@@ -323,17 +323,23 @@ public class ConfigEntry {
             return valueStr;
         }
 
-        //List<String> items = TextUtils.grepWithRegex(valueStr, "\\{A-Za-z?\\}");
-        //正则提取在遇到json格式时，可能有非预期结果。
+        List<String> items = TextUtils.grepWithRegex(valueStr, "\\{[^{}]*?\\}");
 
         List<String> httpParts = MessagePart.getPartList();
         List<ConfigEntry> varConfigs = GUI.configTableModel.getBasicConfigVars();
-
-        for (String part : httpParts) {
-            valueStr = findAndReplace(valueStr, "{" + part + "}", getValueByPartType(messageInfos, part));
-        }
-        for (ConfigEntry config : varConfigs) {
-            valueStr = findAndReplace(valueStr, "{" + config.getKey() + "}", config.getValue());
+        for (String item : items) {
+            String partType = item.replace("{", "").replace("}", "");
+            for (String part : httpParts) {
+                if (partType.equalsIgnoreCase(part)) {
+                    String value = getValueByPartType(messageInfos, partType);
+                    valueStr = valueStr.replace(item, value);
+                }
+            }
+            for (ConfigEntry config : varConfigs) {
+                if (partType.equalsIgnoreCase(config.getKey())) {
+                    valueStr = valueStr.replace(item, config.getValue());
+                }
+            }
         }
         return valueStr;
     }


### PR DESCRIPTION
作者您好，今天我测试时也发现同样Sqlmap调用RequestAsFile文件内容为返回包的问题#94，（dirsearch的{BaseURL}没有反应这个我没使用到，未能复现成功，我测试使用BaseURL正常）我调试了下，发现是修复https://github.com/bit4woo/knife/issues/90 这个bug时引入的新bug,在这个循环时：
![image](https://github.com/user-attachments/assets/b317cdb3-b3a7-44f9-9152-f578d8c2df21)
part 列表中有多个带asFile的名称，使用getValueByPartType获取变量时会不停的生成文件
![image](https://github.com/user-attachments/assets/1b929e90-72eb-442a-986b-4c57abda3a58)
同时，生成文件的命名使用的时间戳为秒级别，同时机器处理循环的速度较快，导致后面生成的Respose的文件名称与前面的文件名称相同，覆盖了前面的文件：建议更改处理逻辑：
![image](https://github.com/user-attachments/assets/73b593a2-2dac-4d6d-badc-2cd37a2c4362)
也可以回滚下前面我提交的PR中的正则我经过测试是可以正常使用，不会出现这种情况，其匹配的是最小{}的内容如{ x{ds}S中匹配的是{ds} 而不是{ x{ds}或其他
![image](https://github.com/user-attachments/assets/be9b1ac4-68f9-4cf5-a6bd-2c9a385eec48)