### PR TITLE
fix: 处理U2C消息中的HTML实体编码

### DIFF
--- a/src/messageTab/U2C/ChinesePanel.java
+++ b/src/messageTab/U2C/ChinesePanel.java
@@ -439,6 +439,18 @@ public class ChinesePanel extends JPanel {
 					}
 				}
 
+				// Handle HTML entity encoding like &#x5bc6; or &#23450;
+				int j = 0;
+				while (contentStr.contains("&#") && j < 3) {
+					int oldLength = contentStr.length();
+					contentStr = StringEscapeUtils.unescapeHtml4(contentStr);
+					j++;
+					int newLength = contentStr.length();
+					if (oldLength == newLength) {
+						break;
+					}
+				}
+
 				displayContent = contentStr.getBytes(charSet);
 			}
 


### PR DESCRIPTION
添加对HTML实体编码（如`&#x5bc6;`或`&#23450;`）的解码处理，确保中文字符正确显示。使用StringEscapeUtils.unescapeHtml4进行解码，最多循环三次以避免无限循环。
---
### 处理前：
<img width="1298" height="968" alt="image" src="https://github.com/user-attachments/assets/326a257e-ec59-4765-a440-c931544ea71e" />

### 处理后：
<img width="1338" height="972" alt="image" src="https://github.com/user-attachments/assets/55b46688-98dd-425e-8fd8-664c70e45aa9" />
